### PR TITLE
seo: canonical, meta description & punycode domain consistency

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,7 +11,7 @@ parameters: &parameters
     firstname: Jibé
     lastname: Barth
     author: '%firstname% %lastname%'
-    website_url: https://jibébarth.fr
+    website_url: https://xn--jibbarth-d1a.fr # jibébarth.fr in punycode — keeps sitemap/og:url/canonical consistent with the served GitHub Pages host
     ga: UA-39521443-1
     analytic_website_id: '%env(ANALYTIC_WEBSITE_ID)%'
     sf_connect_uuid: 7cc4c670-541e-4006-a488-6366794d54dd

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://jibébarth.fr/sitemap.xml
-
+Sitemap: https://xn--jibbarth-d1a.fr/sitemap.xml

--- a/templates/article/list.html.twig
+++ b/templates/article/list.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block title %}✍ Writings // {{ author }}{% endblock %}
-{% block description %}{% endblock %}
+{% block description %}Articles and tutorials about PHP, Symfony and open-source by {{ author }}.{% endblock %}
 {% block meta_image %}{{ unsplash_url('writing', 600, 300) }}{% endblock %}
 {% block header_image %}
     {% set banner = unsplash_photo('writing', 1600, 300) %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -3,7 +3,6 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta http-equiv="X-UA-Compatible" content="ie=edge">
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
@@ -13,6 +12,7 @@
         {# Search Engine #}
         <meta name="author" content="{{ author }}">
         <meta name="description" content="{% block description %}Personal website{% endblock %}">
+        <link rel="canonical" href="{{ (website_url ~ app.request.requestUri)|sanitize_url }}">
         <meta name="image" content="{% block meta_image %}{{ (website_url ~ asset('img/site_preview.png'))|sanitize_url }}{% endblock %}">
         {# Schema.org for Google #}
         <meta itemprop="name" content="{{ block('title') }}">


### PR DESCRIPTION
Fixes from a review of the live site (jibébarth.fr):

- **Add `<link rel="canonical">`** in base layout — was missing everywhere; og:url existed but canonical is the primary SEO signal, especially with the unicode/punycode dual-host situation.
- **Fill empty meta description** on the blog listing (`{% block description %}{% endblock %}` produced an empty tag).
- **Unify domain to punycode** (`xn--jibbarth-d1a.fr`) in `website_url` + `robots.txt` sitemap ref: the site is served on the punycode host via GitHub Pages, but sitemap.xml listed unicode URLs. `sanitize_url` is idempotent so og:url/canonical stay stable.
- **Drop obsolete** `<meta http-equiv="X-UA-Compatible">`.
