### PR TITLE
a11y: hero overlay contrast + mobile tap targets

### DIFF
--- a/templates/_partials/interests.html.twig
+++ b/templates/_partials/interests.html.twig
@@ -1,3 +1,3 @@
 {% for interest in data %}
-    <twig:Badge variant="outline" class="mx-1">{{ interest }}</twig:Badge>
+    <twig:Badge variant="outline" class="mx-1 px-3 py-1.5">{{ interest }}</twig:Badge>
 {% endfor %}

--- a/templates/_partials/social.html.twig
+++ b/templates/_partials/social.html.twig
@@ -4,7 +4,7 @@
         title="{{ type|capitalize }}"
         target="_blank"
         rel="nofollow,noopener"
-        class="inline-flex items-center justify-center w-8 h-8 rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+        class="inline-flex items-center justify-center h-10 w-10 rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
     >
         {{ ux_icon('fa6-brands:' ~ type, {'class': 'icon-inline'}) }}
     </a>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -64,7 +64,7 @@
                         >
                     {% endblock %}
                     {# Overlay to ensure text readability over potential banners #}
-                     <div class="absolute inset-0 bg-background/60 backdrop-blur-[2px]"></div>
+                <div class="absolute inset-0 bg-background/70 backdrop-blur-[2px]"></div>
                 </div>
 
                 <div class="container mx-auto px-4 relative z-10">


### PR DESCRIPTION
Follow-up on the visual review of the live site (screenshots desktop 1280 + mobile 390@2x):

- **Hero overlay /60 -> /70**: subtitle ("Web developer"), publication dates and cert labels were low-contrast on light areas of the blurred Unsplash banners. One-line fix, applies to every page.
- **Social icons w-8/h-8 -> h-10/w-10**: tap targets were ~32px, below the 44px mobile guideline.
- **Interest badges px-3 py-1.5**: at 390px the tag row was a cramped wall of text; slightly larger pills improve tap + breathing room.

Verified visually via browserless screenshots before/after intent; no markup change beyond classes.