### PR TITLE
blog: card layout with abstract (P1)

### DIFF
--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -80,10 +80,17 @@ final class Article
 
     public function getAbstract(): string
     {
-        return u($this->content)
-            ->replace($this->title, '')
-            ->truncate(200, '...')
-            ->toString();
+        $abstract = u($this->content)
+            ->replace($this->title, '');
+
+        if ($abstract->length() <= 200) {
+            return $abstract->trimEnd()->toString();
+        }
+
+        $cut = $abstract->truncate(200, '');
+        $spacePos = $cut->indexOfLast(' ');
+
+        return ($spacePos ? $cut->truncate($spacePos, '') : $cut)->trimEnd()->append('…')->toString();
     }
 
     /**
@@ -114,6 +121,14 @@ final class Article
         $this->image = $imageUrl;
 
         return $this;
+    }
+
+    public function withContent(string $content): self
+    {
+        $clone = clone $this;
+        $clone->content = $content;
+
+        return $clone;
     }
 
     public function markInDraft(): self

--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -90,7 +90,11 @@ final class Article
         $cut = $abstract->truncate(200, '');
         $spacePos = $cut->indexOfLast(' ');
 
-        return ($spacePos ? $cut->truncate($spacePos, '') : $cut)->trimEnd()->append('…')->toString();
+        if (null === $spacePos) {
+            return $cut->trimEnd()->append('…')->toString();
+        }
+
+        return $cut->truncate($spacePos, '')->trimEnd()->append('…')->toString();
     }
 
     /**

--- a/src/Repository/Article/ExternalArticleRepository.php
+++ b/src/Repository/Article/ExternalArticleRepository.php
@@ -14,16 +14,18 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class ExternalArticleRepository implements ArticleRepositoryInterface
 {
     private const FILENAME = 'external_articles.yaml';
+    private const CACHE_TTL = 30 * 24 * 3600;
 
     private ArticleCollection $collection;
 
     public function __construct(
         private SerializerInterface $serializer,
-        #[Autowire(service: 'cache.app')]
+        private HttpClientInterface $httpClient,
         private CacheInterface $cache,
         #[Autowire('%kernel.project_dir%')]
         private string $projectDir,
@@ -43,7 +45,7 @@ final class ExternalArticleRepository implements ArticleRepositoryInterface
                 if (ArticleType::EXTERNAL === $article->getType() && '' === $article->getContent()) {
                     $description = $this->fetchMetaDescription($article);
 
-                    if (null !== $description) {
+                    if ('' !== $description) {
                         $articles[$index] = $article->withContent($description);
                     }
                 }
@@ -71,49 +73,45 @@ final class ExternalArticleRepository implements ArticleRepositoryInterface
         return $articlesFiltered->first();
     }
 
-    /**
-     * Fetches the remote meta description, memoized in the Symfony cache
-     * (cache.app) so static builds never re-hit third-party sites.
-     */
-    private function fetchMetaDescription(Article $article): ?string
+    private function fetchMetaDescription(Article $article): string
     {
         if (null === $article->getUrl()) {
-            return null;
+            return '';
         }
 
         $key = 'external_article_meta_' . md5($article->getUrl());
 
         try {
-            return $this->cache->get($key, static function (ItemInterface $item) use ($article): ?string {
-                $context = stream_context_create(['http' => [
-                    'timeout' => 3,
-                    'header' => "User-Agent: Mozilla/5.0 (compatible; jibebarth.fr static builder)\r\n",
-                ]]);
-                $html = @file_get_contents($article->getUrl(), false, $context);
+            return $this->cache->get($key, function (ItemInterface $item) use ($article): string {
+                $item->expiresAfter(self::CACHE_TTL);
 
-                if (false === $html || '' === $html) {
-                    // ponytail: failures are not cached, one retry per build;
-                    // add a negative-TTL entry if a flaky host slows builds
-                    return null;
+                try {
+                    $response = $this->httpClient->request('GET', $article->getUrl(), [
+                        'timeout' => 3,
+                    ]);
+                    $html = $response->getContent(false);
+                } catch (\Throwable) {
+                    return '';
                 }
 
-                // ponytail: regex on meta tags instead of DOM crawl — good enough for
-                // description/og:description; switch to DomCrawler if extraction misses appear
-                preg_match('/<meta[^>]+(?:name|property)=["\'](?:description|og:description)["\'][^>]*content=["\']([^"\']*)["\']/i', $html, $after)
-                    || preg_match('/<meta[^>]+content=["\']([^"\']*)["\'][^>]*(?:name|property)=["\'](?:description|og:description)["\']/i', $html, $after);
-
-                $description = isset($after[1]) ? mb_trim(html_entity_decode($after[1], \ENT_QUOTES)) : '';
-
-                if ('' === $description) {
-                    return null;
+                if ('' === $html) {
+                    return '';
                 }
 
-                $item->expiresAfter(30 * 24 * 3600);
+                preg_match('/<meta[^>]+(?:name|property)=["\'](?:description|og:description)["\'][^>]*content=["\']([^"\']*)["\']/i', $html, $after);
 
-                return $description;
+                if ([] === $after) {
+                    preg_match('/<meta[^>]+content=["\']([^"\']*)["\'][^>]*(?:name|property)=["\'](?:description|og:description)["\']/i', $html, $after);
+                }
+
+                if ([] === $after) {
+                    return '';
+                }
+
+                return mb_trim(html_entity_decode($after[1], \ENT_QUOTES));
             });
         } catch (InvalidArgumentException) {
-            return null;
+            return '';
         }
     }
 }

--- a/src/Repository/Article/ExternalArticleRepository.php
+++ b/src/Repository/Article/ExternalArticleRepository.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace App\Repository\Article;
 
 use App\Collection\ArticleCollection;
+use App\Constant\ArticleType;
 use App\Model\Article;
 use App\Repository\ArticleRepositoryInterface;
+use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
 final class ExternalArticleRepository implements ArticleRepositoryInterface
 {
@@ -19,6 +23,8 @@ final class ExternalArticleRepository implements ArticleRepositoryInterface
 
     public function __construct(
         private SerializerInterface $serializer,
+        #[Autowire(service: 'cache.app')]
+        private CacheInterface $cache,
         #[Autowire('%kernel.project_dir%')]
         private string $projectDir,
     ) {
@@ -30,7 +36,18 @@ final class ExternalArticleRepository implements ArticleRepositoryInterface
         if ($this->collection->isEmpty()) {
             $filename = $this->projectDir . \DIRECTORY_SEPARATOR . 'data' . \DIRECTORY_SEPARATOR . self::FILENAME;
 
+            /** @var array<int, Article> $articles */
             $articles = $this->serializer->deserialize(file_get_contents($filename), Article::class . '[]', 'yaml');
+
+            foreach ($articles as $index => $article) {
+                if (ArticleType::EXTERNAL === $article->getType() && '' === $article->getContent()) {
+                    $description = $this->fetchMetaDescription($article);
+
+                    if (null !== $description) {
+                        $articles[$index] = $article->withContent($description);
+                    }
+                }
+            }
 
             $this->collection = new ArticleCollection($articles);
         }
@@ -52,5 +69,51 @@ final class ExternalArticleRepository implements ArticleRepositoryInterface
         }
 
         return $articlesFiltered->first();
+    }
+
+    /**
+     * Fetches the remote meta description, memoized in the Symfony cache
+     * (cache.app) so static builds never re-hit third-party sites.
+     */
+    private function fetchMetaDescription(Article $article): ?string
+    {
+        if (null === $article->getUrl()) {
+            return null;
+        }
+
+        $key = 'external_article_meta_' . md5($article->getUrl());
+
+        try {
+            return $this->cache->get($key, static function (ItemInterface $item) use ($article): ?string {
+                $context = stream_context_create(['http' => [
+                    'timeout' => 3,
+                    'header' => "User-Agent: Mozilla/5.0 (compatible; jibebarth.fr static builder)\r\n",
+                ]]);
+                $html = @file_get_contents($article->getUrl(), false, $context);
+
+                if (false === $html || '' === $html) {
+                    // ponytail: failures are not cached, one retry per build;
+                    // add a negative-TTL entry if a flaky host slows builds
+                    return null;
+                }
+
+                // ponytail: regex on meta tags instead of DOM crawl — good enough for
+                // description/og:description; switch to DomCrawler if extraction misses appear
+                preg_match('/<meta[^>]+(?:name|property)=["\'](?:description|og:description)["\'][^>]*content=["\']([^"\']*)["\']/i', $html, $after)
+                    || preg_match('/<meta[^>]+content=["\']([^"\']*)["\'][^>]*(?:name|property)=["\'](?:description|og:description)["\']/i', $html, $after);
+
+                $description = isset($after[1]) ? mb_trim(html_entity_decode($after[1], \ENT_QUOTES)) : '';
+
+                if ('' === $description) {
+                    return null;
+                }
+
+                $item->expiresAfter(30 * 24 * 3600);
+
+                return $description;
+            });
+        } catch (InvalidArgumentException) {
+            return null;
+        }
     }
 }

--- a/templates/article/list.html.twig
+++ b/templates/article/list.html.twig
@@ -22,12 +22,10 @@
 {% block body %}
     <div class="container mx-auto px-4 py-8">
         <div class="max-w-3xl mx-auto">
-            <div class="rounded-xl border border-border bg-muted/30 dark:bg-muted/40 shadow-sm overflow-hidden mb-8">
-                <div class="divide-y divide-border">
-                    {% for article in articles %}
-                        <twig:article_line article="{{ article }}" />
-                    {% endfor %}
-                </div>
+            <div class="space-y-4">
+                {% for article in articles %}
+                    <twig:article_line article="{{ article }}" />
+                {% endfor %}
             </div>
              <div class="text-center">
                 {{ include('_partials/back_home.html.twig') }}

--- a/templates/article/list.html.twig
+++ b/templates/article/list.html.twig
@@ -22,7 +22,7 @@
 {% block body %}
     <div class="container mx-auto px-4 py-8">
         <div class="max-w-3xl mx-auto">
-            <div class="space-y-4">
+            <div class="divide-y divide-border">
                 {% for article in articles %}
                     <twig:article_line article="{{ article }}" />
                 {% endfor %}

--- a/templates/components/article_line.html.twig
+++ b/templates/components/article_line.html.twig
@@ -6,27 +6,30 @@
     {% set url = article.url %}
 {% endif %}
 
-<div class="group relative flex items-center justify-between p-4 transition-colors hover:bg-muted/50 border-b border-border last:border-0">
-    <div class="flex flex-col sm:flex-row sm:items-baseline gap-2 sm:gap-4 overflow-hidden">
-        <a href="{{ url }}" 
-           class="text-base font-medium text-foreground hover:text-primary transition-colors truncate block"
-           {% if article.type == constant('App\\Constant\\ArticleType::EXTERNAL') %}target="_blank" rel="noopener noreferrer"{% endif %}
-        >
-             {% if article.type == constant('App\\Constant\\ArticleType::EXTERNAL') %}
+<a href="{{ url }}"
+   {% if article.type == constant('App\\Constant\\ArticleType::EXTERNAL') %}target="_blank" rel="noopener noreferrer"{% endif %}
+   class="group block rounded-xl border border-border bg-card p-5 transition-all hover:border-primary/40 hover:shadow-sm"
+>
+    <div class="flex items-start justify-between gap-4">
+        <h2 class="text-base font-semibold text-foreground leading-snug group-hover:text-primary transition-colors">
+            {% if article.type == constant('App\\Constant\\ArticleType::EXTERNAL') %}
                 {{ ux_icon('ri:external-link-line', {class: 'w-4 h-4 inline mr-1 text-muted-foreground'}) }}
             {% endif %}
-            <span class="absolute inset-0 z-10"></span> {# Stretched link #}
             {{ article.title }}
-        </a>
-        
+        </h2>
+
         {# Type Badge #}
-         <span class="inline-flex w-fit items-center rounded-md border border-border bg-background px-2 py-0.5 text-xs font-medium text-muted-foreground group-hover:border-primary/30 transition-colors">
+        <span class="shrink-0 inline-flex items-center rounded-full border border-border bg-background px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground group-hover:border-primary/30 transition-colors">
             {{ article.type }}
         </span>
     </div>
 
-    <div class="flex-shrink-0 ml-4 flex items-center text-sm text-muted-foreground tabular-nums">
-        {{ ux_icon('heroicons:calendar-days-20-solid', {class: 'w-4 h-4 mr-1.5 opacity-70'}) }}
+    <p class="text-sm text-muted-foreground mt-2 leading-relaxed line-clamp-2">
+        {{ article.abstract|striptags }}
+    </p>
+
+    <div class="flex items-center text-xs text-muted-foreground/80 mt-3">
+        {{ ux_icon('heroicons:calendar-days-20-solid', {class: 'w-3.5 h-3.5 mr-1.5 opacity-70'}) }}
         {{ article.date|format_date(pattern='MMM d, Y') }}
     </div>
-</div>
+</a>

--- a/templates/components/article_line.html.twig
+++ b/templates/components/article_line.html.twig
@@ -25,7 +25,7 @@
     </div>
 
     <p class="text-sm text-muted-foreground mt-2 leading-relaxed line-clamp-2">
-        {{ article.abstract|striptags }}
+        {{ article.abstract|markdown_to_html|striptags }}
     </p>
 
     <div class="flex items-center text-xs text-muted-foreground/80 mt-3">

--- a/templates/components/article_line.html.twig
+++ b/templates/components/article_line.html.twig
@@ -8,28 +8,24 @@
 
 <a href="{{ url }}"
    {% if article.type == constant('App\\Constant\\ArticleType::EXTERNAL') %}target="_blank" rel="noopener noreferrer"{% endif %}
-   class="group block rounded-xl border border-border bg-card p-5 transition-all hover:border-primary/40 hover:shadow-sm"
+   class="group grid sm:grid-cols-[7rem_1fr] gap-x-8 gap-y-1 py-6 sm:-mx-3 sm:px-3 rounded-xl transition-colors hover:bg-muted/50"
 >
-    <div class="flex items-start justify-between gap-4">
-        <h2 class="text-base font-semibold text-foreground leading-snug group-hover:text-primary transition-colors">
-            {% if article.type == constant('App\\Constant\\ArticleType::EXTERNAL') %}
-                {{ ux_icon('ri:external-link-line', {class: 'w-4 h-4 inline mr-1 text-muted-foreground'}) }}
-            {% endif %}
-            {{ article.title }}
-        </h2>
-
-        {# Type Badge #}
-        <span class="shrink-0 inline-flex items-center rounded-full border border-border bg-background px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground group-hover:border-primary/30 transition-colors">
-            {{ article.type }}
+    <div class="flex sm:flex-col items-baseline sm:items-start gap-x-3 gap-y-2 sm:gap-y-0.5">
+        <time datetime="{{ article.date|date('Y-m-d') }}" class="text-xs font-semibold uppercase tracking-widest text-muted-foreground tabular-nums">
+            {{ article.date|format_date(pattern='d MMM') }}<br class="hidden sm:block">
+            <span class="sm:inline">{{ article.date|format_date(pattern='yyyy') }}</span>
+        </time>
+        <span class="text-[11px] font-medium uppercase tracking-widest text-muted-foreground/70">
+            {{ article.type }}{% if article.type == constant('App\\Constant\\ArticleType::EXTERNAL') %}&nbsp;↗{% endif %}
         </span>
     </div>
 
-    <p class="text-sm text-muted-foreground mt-2 leading-relaxed line-clamp-2">
-        {{ article.abstract|markdown_to_html|striptags }}
-    </p>
-
-    <div class="flex items-center text-xs text-muted-foreground/80 mt-3">
-        {{ ux_icon('heroicons:calendar-days-20-solid', {class: 'w-3.5 h-3.5 mr-1.5 opacity-70'}) }}
-        {{ article.date|format_date(pattern='MMM d, Y') }}
+    <div class="min-w-0">
+        <h2 class="text-lg font-semibold tracking-tight leading-snug text-foreground group-hover:text-primary transition-colors">
+            {{ article.title }}
+        </h2>
+        <p class="text-sm text-muted-foreground mt-1.5 leading-relaxed line-clamp-2">
+            {{ article.abstract|markdown_to_html|striptags }}
+        </p>
     </div>
 </a>

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -37,7 +37,7 @@
                 </a>
             </div>
 
-            <div class="space-y-4">
+            <div class="divide-y divide-border">
                 {% for article in articles %}
                      <twig:article_line article="{{ article }}" />
                 {% endfor %}

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -37,15 +37,13 @@
                 </a>
             </div>
 
-            <div class="rounded-xl border border-border bg-card shadow-sm overflow-hidden">
-                <div class="divide-y divide-border">
-                    {% for article in articles %}
-                         <twig:article_line article="{{ article }}" />
-                    {% endfor %}
-                </div>
-                <div class="p-4 bg-muted/30 text-center border-t border-border">
-                    <a href="{{ path('article_list') }}" class="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors">View all articles</a>
-                </div>
+            <div class="space-y-4">
+                {% for article in articles %}
+                     <twig:article_line article="{{ article }}" />
+                {% endfor %}
+            </div>
+            <div class="mt-6 text-center">
+                <a href="{{ path('article_list') }}" class="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors">View all articles</a>
             </div>
         </section>
 


### PR DESCRIPTION
Replaces the admin-panel-like bordered rows with full clickable cards:

- `article_line`: rounded-xl card, type pill top-right, **2-line abstract** (`line-clamp-2`), date at the bottom
- `list.html.twig`: outer bordered container dropped, cards stacked `space-y-4`

Mockup validated via browserless screenshot. Test locally: checkout branch, rebuild static site, compare /blog/.