### PR TITLE
ux: dedupe social icons — keep navbar set (P2)

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -86,7 +86,6 @@
                             </p>
                             <div class="text-xl text-muted-foreground mb-6 leading-relaxed">
                                 🇫🇷 Web developer
-                                <div>{{ partial('social') }}</div>
                             </div>
                         </div>
                     </div>

--- a/templates/components/navbar.html.twig
+++ b/templates/components/navbar.html.twig
@@ -47,6 +47,12 @@
             <div class="px-4 py-6 space-y-4">
                  <a href="{{ path('article_list') }}" class="block text-base font-medium hover:text-primary">Blog</a>
                  <div class="border-t border-border my-4 pt-4 flex items-center justify-between">
+                     <span class="text-sm font-medium text-muted-foreground">Social</span>
+                     <div class="flex items-center gap-1 -mr-2 text-muted-foreground">
+                         {{ partial('social') }}
+                     </div>
+                 </div>
+                 <div class="border-t border-border my-4 pt-4 flex items-center justify-between">
                      <span class="text-sm font-medium text-muted-foreground">Theme</span>
                      <button data-controller="theme" data-action="theme#toggle" class="p-2 rounded-md hover:bg-accent transition-colors" aria-label="Toggle theme">
                         <span class="dark:hidden flex items-center gap-2">{{ ux_icon('ri:moon-line') }} Dark</span>


### PR DESCRIPTION
Social icons currently render twice per page (navbar + hero).

This removes the hero duplicate; navbar keeps the full set.
Alternative kept in mind: inverse (hero only + minimal navbar) — say the word and I'll flip it.