### PR TITLE
ux: fade hero into content (P3)

### DIFF
--- a/templates/article/gist.html.twig
+++ b/templates/article/gist.html.twig
@@ -8,7 +8,7 @@
 {% block header_image %}
     {% set banner = unsplash_photo('coding', 1600, 300) %}
     <img
-        class="absolute inset-0 w-full h-full object-cover opacity-20"
+        class="absolute inset-0 w-full h-full object-cover opacity-50"
         src="{{ banner.blurhash }}"
         {{ stimulus_controller('symfony/ux-lazy-image/lazy-image', {
             src: banner.fullUrl

--- a/templates/article/list.html.twig
+++ b/templates/article/list.html.twig
@@ -6,7 +6,7 @@
 {% block header_image %}
     {% set banner = unsplash_photo('writing', 1600, 300) %}
     <img
-        class="absolute inset-0 w-full h-full object-cover opacity-20"
+        class="absolute inset-0 w-full h-full object-cover opacity-60"
         src="{{ banner.blurhash }}"
         {{ stimulus_controller('symfony/ux-lazy-image/lazy-image', {
             src: banner.fullUrl

--- a/templates/article/post.html.twig
+++ b/templates/article/post.html.twig
@@ -8,7 +8,7 @@
 {% block header_image %}
     {% if article.image is not null %}
         <img
-            class="absolute inset-0 w-full h-full object-cover opacity-30"
+            class="absolute inset-0 w-full h-full object-cover opacity-60"
             src="{{ article.image }}"
              alt="Banner image for this article">
     {% else %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -55,7 +55,7 @@
                     {% block header_image %}
                          {% set bannerPhoto = unsplash_photo('website', 1600, 200) %}
                          <img
-                            class="absolute inset-0 w-full h-full object-cover opacity-50"
+                            class="absolute inset-0 w-full h-full object-cover opacity-70"
                             src="{{ bannerPhoto.blurhash }}"
                             {{ stimulus_controller('symfony/ux-lazy-image/lazy-image', {
                                 src: bannerPhoto.fullUrl

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -51,7 +51,7 @@
             <twig:navbar />
             <div class="relative pt-24 pb-12 overflow-hidden bg-background">
                  {# Background Image / Effect Area #}
-                <div class="absolute inset-0 z-0">
+                <div class="absolute inset-0 z-0 [mask-image:linear-gradient(to_bottom,black_65%,transparent)] [-webkit-mask-image:linear-gradient(to_bottom,black_65%,transparent)]">
                     {% block header_image %}
                          {% set bannerPhoto = unsplash_photo('website', 1600, 200) %}
                          <img

--- a/templates/project/list.html.twig
+++ b/templates/project/list.html.twig
@@ -6,7 +6,7 @@
 {% block header_image %}
     {% set banner = unsplash_photo('project', 1600, 300) %}
     <img
-        class="absolute inset-0 w-full h-full object-cover opacity-20"
+        class="absolute inset-0 w-full h-full object-cover opacity-60"
         src="{{ banner.blurhash }}"
         {{ stimulus_controller('symfony/ux-lazy-image/lazy-image', {
             src: banner.fullUrl


### PR DESCRIPTION
Adds a 96px bottom gradient strip inside the hero banner (`transparent -> background`), so the blurred photo fades into the page instead of a hard cut.

One line in base.html.twig, applies to every page.